### PR TITLE
Oppdater ktor og altinn-rettigheter-proxy-klient

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -71,7 +71,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/hent-riktig-status-etter-tema-er-stengt'
+    if: github.ref == 'refs/heads/oppdater-ktor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-val ktorVersion = "2.3.12"
+val ktorVersion = "3.0.1"
 val kotlinVersion = "2.0.20"
 val logbackVersion = "1.5.8"
 val prometheusVersion = "1.13.5"
@@ -23,18 +23,23 @@ dependencies {
     // Felles definisjoner for IA-domenet
     implementation("com.github.navikt:ia-felles:$iaFellesVersion")
 
+    implementation("io.micrometer:micrometer-registry-prometheus:$prometheusVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-jackson-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-metrics-micrometer-jvm:$ktorVersion")
-    implementation("io.micrometer:micrometer-registry-prometheus:$prometheusVersion")
     implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-auth-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-server-auth-jwt-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-rate-limit:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-apache:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-jackson-jvm:$ktorVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:8.0")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
@@ -46,7 +51,7 @@ dependencies {
     implementation("io.lettuce:lettuce-core:6.4.0.RELEASE")
 
     // altinn-klient
-    implementation("no.nav.arbeidsgiver:altinn-rettigheter-proxy-klient:4.0.0")
+    implementation("com.github.navikt:altinn-rettigheter-proxy-klient:altinn-rettigheter-proxy-klient-5.0.0")
 
     // altinn-rettigheter-proxy bruker codec 1.11 som har en sårbarhet
     implementation("commons-codec:commons-codec:1.17.1")
@@ -59,8 +64,6 @@ dependencies {
 
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-json:$kotestVersion")
-
-    testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
 

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/Routing.kt
@@ -2,11 +2,11 @@ package no.nav.fia.arbeidsgiver.konfigurasjon.plugins
 
 import VerifisertSesjonId
 import io.ktor.server.application.Application
-import io.ktor.server.application.install
 import io.ktor.server.auth.authenticate
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.RouteSelector
 import io.ktor.server.routing.RouteSelectorEvaluation
+import io.ktor.server.routing.RoutingNode
 import io.ktor.server.routing.RoutingResolveContext
 import io.ktor.server.routing.routing
 import no.nav.fia.arbeidsgiver.http.helse
@@ -54,13 +54,13 @@ fun Application.configureRouting(
 fun Route.auditLogged(
     spørreundersøkelseService: SpørreundersøkelseService,
     authorizedRoutes: Route.() -> Unit,
-) = createChild(selector).apply {
+) = (this as RoutingNode).createChild(selector).apply {
     install(AuditLogged(spørreundersøkelseService = spørreundersøkelseService))
     authorizedRoutes()
 }
 
 fun Route.medVerifisertAltinnTilgang(authorizedRoutes: Route.() -> Unit) =
-    createChild(selector).apply {
+    (this as RoutingNode).createChild(selector).apply {
         install(AuthorizationPlugin)
         authorizedRoutes()
     }
@@ -74,7 +74,7 @@ fun Route.medVerifisertSesjonId(
 }
 
 private class CustomSelector : RouteSelector() {
-    override fun evaluate(
+    override suspend fun evaluate(
         context: RoutingResolveContext,
         segmentIndex: Int,
     ) = RouteSelectorEvaluation.Transparent

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/sporreundersokelse/api/SpørreundersøkelseDeltakerRoutes.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/sporreundersokelse/api/SpørreundersøkelseDeltakerRoutes.kt
@@ -1,8 +1,6 @@
 package no.nav.fia.arbeidsgiver.sporreundersokelse.api
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.application
-import io.ktor.server.application.call
 import io.ktor.server.application.log
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -89,7 +87,7 @@ fun Route.spørreundersøkelseDeltaker(spørreundersøkelseService: Spørreunder
         }
 
         if (spørreundersøkelseService.erTemaStengt(spørreundersøkelseId, temaId)) {
-            application.log.info("Tema '$temaId' er stengt, hent nytt spørsmål")
+            call.application.log.info("Tema '$temaId' er stengt, hent nytt spørsmål")
             call.respond(
                 message = "Tema '$temaId' er stengt, hent nytt spørsmål",
                 status = HttpStatusCode.SeeOther,


### PR DESCRIPTION
 - ktor -> 3.0.1
 - oppdater altinn-rettigheter-proxy-klient til 5.0.0 da det ble krøll med ktor 3.0.1 i fia-ag og ktor 2.x.x i altinn-klient
 - henter altinn-rettigheter-proxy-klient fra jitpack, da det var problemer med å release ny versjon til maven-central