### PR TITLE
Slutt a verifisere altinn2 tilgang

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy branch to dev
     needs: build
-    if: github.ref == 'refs/heads/ta-i-bruk-altinn-tilganger'
+    if: github.ref == 'refs/heads/slutt-a-verifisere-altinn2-tilgang'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
@@ -25,20 +25,16 @@ class AltinnTilgangerService {
     companion object {
         private val altinnTilgangerUrl: String = "$altinnTilgangerProxyUrl/altinn-tilganger"
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
-        const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2 = "5934:1"
         const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3 = "nav_forebygge-og-redusere-sykefravar_samarbeid"
 
         fun AltinnTilganger?.harTilgangTilOrgnr(orgnr: String?): Boolean =
             this?.virksomheterVedkommendeHarTilgangTil()?.contains(orgnr) ?: false
 
         fun AltinnTilganger?.harEnkeltrettighet(orgnr: String?): Boolean =
-            harAltinn3Enkeltrettighet(orgnr) || harAltinn2Enkeltrettighet(orgnr)
+            harAltinn3Enkeltrettighet(orgnr)
 
         private fun AltinnTilganger?.harAltinn3Enkeltrettighet(orgnr: String?): Boolean =
             this?.orgNrTilTilganger?.get(orgnr)?.contains(ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3) ?: false
-
-        private fun AltinnTilganger?.harAltinn2Enkeltrettighet(orgnr: String?) =
-            this?.orgNrTilTilganger?.get(orgnr)?.contains(ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2) ?: false
 
         private fun AltinnTilganger?.virksomheterVedkommendeHarTilgangTil(): List<String> =
             this?.hierarki?.flatMap {

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/audit/AuditLogTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/audit/AuditLogTest.kt
@@ -26,7 +26,7 @@ class AuditLogTest {
     fun `det skal auditlogges (Permit) dersom man går mot status med gyldig token og altinn tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn2Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
         )
         runBlocking {
             applikasjon.performGet("$SAMARBEIDSSTATUS_PATH/$ALTINN_ORGNR_1", withTokenXToken())

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
@@ -60,7 +60,6 @@ class AltinnTilgangerContainerHelper(
     internal fun leggTilRettigheter(
         overordnetEnhet: String = "400000000",
         underenhet: String,
-        altinn2Rettighet: String = "",
         altinn3Rettighet: String = "",
     ) {
         log.debug(
@@ -68,7 +67,7 @@ class AltinnTilgangerContainerHelper(
                 container.getMappedPort(
                     7070,
                 )
-            }'. Legger til rettighet '$altinn2Rettighet' for underenhet '$underenhet'",
+            }'. Legger til rettighet '$altinn3Rettighet' for underenhet '$underenhet'",
         )
         val client = MockServerClient(
             container.host,
@@ -94,9 +93,7 @@ class AltinnTilgangerContainerHelper(
                               "altinn3Tilganger": [
                                 "$altinn3Rettighet"
                               ],
-                              "altinn2Tilganger": [
-                                "$altinn2Rettighet"
-                              ],
+                              "altinn2Tilganger": [],
                               "underenheter": [],
                               "navn": "NAVN TIL UNDERENHET",
                               "organisasjonsform": "BEDR"
@@ -108,15 +105,11 @@ class AltinnTilgangerContainerHelper(
                       ],
                       "orgNrTilTilganger": {
                         "$underenhet": [
-                          "$altinn3Rettighet",
-                          "$altinn2Rettighet"
+                          "$altinn3Rettighet"
                         ]
                       },
                       "tilgangTilOrgNr": {
                         "$altinn3Rettighet": [
-                          "$underenhet"
-                        ],
-                        "$altinn2Rettighet": [
                           "$underenhet"
                         ]
                       },

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
@@ -18,7 +18,6 @@ import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.kafka
 import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.shouldContainLog
 import no.nav.fia.arbeidsgiver.helper.performGet
 import no.nav.fia.arbeidsgiver.helper.withTokenXToken
-import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.dto.SamarbeidsstatusDTO
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.dto.Samarbeidsstaus
@@ -86,7 +85,7 @@ class SamarbeidsstatusTest {
     fun `skal få 200 (OK) dersom man går mot status med gyldig token og altinn2 tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn2Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_2,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
         )
         runBlocking {
             applikasjon.performGet(


### PR DESCRIPTION
Fjerne kode som sjekker enkeltrettighet "Forebygge fravær" på Altinn2 kode (service code / service edition)
I stedet, bare sjekk enkeltrettighet "Forebygge fravær" på Altinn3 kode (ressurs Id) 