### PR TITLE
Nytt endepunkt organisasjoner

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy branch to dev
     needs: build
-    if: github.ref == 'refs/heads/slutt-a-verifisere-altinn2-tilgang'
+    if: github.ref == 'refs/heads/nytt-endepunkt-organisasjoner'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/AuthorizationPlugin.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/AuthorizationPlugin.kt
@@ -5,21 +5,19 @@ import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.response.respond
 import kotlinx.serialization.Serializable
-import no.nav.fia.arbeidsgiver.http.hentToken
 import no.nav.fia.arbeidsgiver.http.orgnr
-import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.harEnkeltrettighet
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.harTilgangTilOrgnr
 import org.slf4j.LoggerFactory
 
 @Suppress("ktlint:standard:function-naming")
-fun AltinnAuthorizationPlugin(altinnTilgangerService: AltinnTilgangerService) =
+fun AltinnAuthorizationPlugin(enkelrettighet: String) =
     createRouteScopedPlugin(name = "AuthorizationPlugin") {
         pluginConfig.apply {
             val logger = LoggerFactory.getLogger(this::class.java)
-            on(AuthenticationChecked) { call ->
-                val token = call.request.hentToken() ?: return@on call.respond(HttpStatusCode.Forbidden)
-                val altinnTilganger = altinnTilgangerService.hentAltinnTilganger(token = token)
+            on(hook = AuthenticationChecked) { call ->
+                val tilganger = call.attributes[AltinnTilgangerKey]
+                val altinnTilganger = tilganger.altinnTilganger
                 val orgnr = call.orgnr ?: return@on call.respond(HttpStatusCode.BadRequest)
 
                 if (!altinnTilganger.harTilgangTilOrgnr(orgnr)) {
@@ -31,11 +29,15 @@ fun AltinnAuthorizationPlugin(altinnTilgangerService: AltinnTilgangerService) =
                     return@on
                 }
 
-                if (!altinnTilganger.harEnkeltrettighet(orgnr)) {
-                    logger.debug("Ikke tilgang til enkeltrettighet")
+                if (!altinnTilganger.harEnkeltrettighet(
+                        orgnr = orgnr,
+                        enkeltrettighet = enkelrettighet
+                    )
+                ) {
+                    logger.debug("Ikke tilgang til ressurs pga manglende enkeltrettighet '$enkelrettighet'")
                     call.respond(
                         status = HttpStatusCode.Forbidden,
-                        message = ResponseIError(message = "Ikke tilgang til orgnummer"),
+                        message = ResponseIError(message = "Har ikke tilgang til resurs for orgnummer"),
                     )
                     return@on
                 }

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/Routing.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.RoutingResolveContext
 import io.ktor.server.routing.routing
 import no.nav.fia.arbeidsgiver.http.helse
 import no.nav.fia.arbeidsgiver.konfigurasjon.ApplikasjonsHelse
+import no.nav.fia.arbeidsgiver.organisasjoner.api.organisasjoner
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.samarbeidsstatus
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.domene.SamarbeidsstatusService
@@ -42,6 +43,7 @@ fun Application.configureRouting(
 
         authenticate("tokenx") {
             auditLogged(spørreundersøkelseService = spørreundersøkelseService) {
+                organisasjoner(altinnTilgangerService = altinnTilgangerService)
                 medVerifisertAltinnEnkeltrettighet(
                     altinnTilgangerService = altinnTilgangerService,
                 ) {

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/UthentingAvOrganisasjonerIAltinnPlugin.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/konfigurasjon/plugins/UthentingAvOrganisasjonerIAltinnPlugin.kt
@@ -1,0 +1,37 @@
+package no.nav.fia.arbeidsgiver.konfigurasjon.plugins
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.auth.AuthenticationChecked
+import io.ktor.server.response.respond
+import io.ktor.util.AttributeKey
+import no.nav.fia.arbeidsgiver.http.hentToken
+import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService
+import org.slf4j.LoggerFactory
+
+@Suppress("ktlint:standard:function-naming")
+fun UthentingAvOrganisasjonerIAltinnPlugin(altinnTilgangerService: AltinnTilgangerService) =
+    createRouteScopedPlugin(name = "UthentingAvOrganisasjonerIAltinnPlugin") {
+        pluginConfig.apply {
+            val logger = LoggerFactory.getLogger(this::class.java)
+            logger.debug("Henter organisasjoner i Altinn")
+
+            on(hook = AuthenticationChecked) { call ->
+                val token = call.request.hentToken() ?: return@on call.respond(HttpStatusCode.Forbidden)
+                val altinnTilganger = altinnTilgangerService.hentAltinnTilganger(token = token)
+
+                call.attributes.put(
+                    AltinnTilgangerKey,
+                    AltinnTilgangerOnCall(
+                        altinnTilganger = altinnTilganger,
+                    ),
+                )
+            }
+        }
+    }
+
+val AltinnTilgangerKey = AttributeKey<AltinnTilgangerOnCall>("AltinnTilganger")
+
+data class AltinnTilgangerOnCall(
+    val altinnTilganger: AltinnTilgangerService.AltinnTilganger?,
+)

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerRoute.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerRoute.kt
@@ -1,0 +1,21 @@
+package no.nav.fia.arbeidsgiver.organisasjoner.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import no.nav.fia.arbeidsgiver.http.hentToken
+import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService
+
+const val ORGANISASJONER_PATH = "/fia-arbeidsgiver/organisasjoner"
+
+fun Route.organisasjoner(altinnTilgangerService: AltinnTilgangerService) {
+    get(path = ORGANISASJONER_PATH) {
+        val token = call.request.hentToken() ?: return@get call.respond(HttpStatusCode.Forbidden)
+        val sthg = altinnTilgangerService.hentAltinnTilganger(token = token)
+        call.respond(
+            status = HttpStatusCode.OK,
+            message = sthg?.hierarki ?: emptyList(),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerRoute.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerRoute.kt
@@ -4,18 +4,17 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import no.nav.fia.arbeidsgiver.http.hentToken
-import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService
+import no.nav.fia.arbeidsgiver.konfigurasjon.plugins.AltinnTilgangerKey
 
 const val ORGANISASJONER_PATH = "/fia-arbeidsgiver/organisasjoner"
 
-fun Route.organisasjoner(altinnTilgangerService: AltinnTilgangerService) {
+fun Route.organisasjoner() {
     get(path = ORGANISASJONER_PATH) {
-        val token = call.request.hentToken() ?: return@get call.respond(HttpStatusCode.Forbidden)
-        val sthg = altinnTilgangerService.hentAltinnTilganger(token = token)
+        val tilganger = call.attributes[AltinnTilgangerKey]
+
         call.respond(
             status = HttpStatusCode.OK,
-            message = sthg?.hierarki ?: emptyList(),
+            message = tilganger.altinnTilganger?.hierarki ?: emptyList(),
         )
     }
 }

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
@@ -27,6 +27,7 @@ class AltinnTilgangerService {
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
         const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID = "nav_forebygge-og-redusere-sykefravar_samarbeid"
+        // Usikker om vi kommer til å bruke denne da det er en annen tjeneste som henter ut statistikk
         const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SYKEFRAVÆRSSTATISTIKK =
             "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
 

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
@@ -96,7 +96,7 @@ class AltinnTilgangerService {
         val underenheter: List<AltinnTilgang>,
         val navn: String,
         val organisasjonsform: String,
-        val erSlettet: Boolean = false,
+        val erSlettet: Boolean,
     )
 
     @Serializable

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/AltinnTilgangerService.kt
@@ -22,19 +22,22 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class AltinnTilgangerService {
+    private val altinnTilgangerUrl: String = "$altinnTilgangerProxyUrl/altinn-tilganger"
+
     companion object {
-        private val altinnTilgangerUrl: String = "$altinnTilgangerProxyUrl/altinn-tilganger"
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
-        const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3 = "nav_forebygge-og-redusere-sykefravar_samarbeid"
+        const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID = "nav_forebygge-og-redusere-sykefravar_samarbeid"
+        const val ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SYKEFRAVÆRSSTATISTIKK =
+            "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
 
         fun AltinnTilganger?.harTilgangTilOrgnr(orgnr: String?): Boolean =
             this?.virksomheterVedkommendeHarTilgangTil()?.contains(orgnr) ?: false
 
-        fun AltinnTilganger?.harEnkeltrettighet(orgnr: String?): Boolean =
-            harAltinn3Enkeltrettighet(orgnr)
-
-        private fun AltinnTilganger?.harAltinn3Enkeltrettighet(orgnr: String?): Boolean =
-            this?.orgNrTilTilganger?.get(orgnr)?.contains(ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3) ?: false
+        fun AltinnTilganger?.harEnkeltrettighet(
+            orgnr: String?,
+            enkeltrettighet: String = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID
+        ): Boolean =
+            this?.orgNrTilTilganger?.get(orgnr)?.contains(enkeltrettighet) ?: false
 
         private fun AltinnTilganger?.virksomheterVedkommendeHarTilgangTil(): List<String> =
             this?.hierarki?.flatMap {

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/audit/AuditLogTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/audit/AuditLogTest.kt
@@ -11,7 +11,7 @@ import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.shouldContai
 import no.nav.fia.arbeidsgiver.helper.performGet
 import no.nav.fia.arbeidsgiver.helper.stengTema
 import no.nav.fia.arbeidsgiver.helper.withTokenXToken
-import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3
+import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.SAMARBEIDSSTATUS_PATH
 import no.nav.fia.arbeidsgiver.sporreundersokelse.api.VERT_BASEPATH
 import org.junit.Before
@@ -26,7 +26,7 @@ class AuditLogTest {
     fun `det skal auditlogges (Permit) dersom man går mot status med gyldig token og altinn tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             applikasjon.performGet("$SAMARBEIDSSTATUS_PATH/$ALTINN_ORGNR_1", withTokenXToken())

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
@@ -18,6 +18,7 @@ class AltinnTilgangerContainerHelper(
     companion object {
         const val ALTINN_ORGNR_1 = "311111111"
         const val ALTINN_ORGNR_2 = "322222222"
+        const val ALTINN_OVERORDNET_ENHET = "400000000"
         const val ORGNR_UTEN_TILKNYTNING = "300000000"
     }
 
@@ -58,7 +59,7 @@ class AltinnTilgangerContainerHelper(
     }
 
     internal fun leggTilRettigheter(
-        overordnetEnhet: String = "400000000",
+        overordnetEnhet: String = ALTINN_OVERORDNET_ENHET,
         underenhet: String,
         altinn3Rettighet: String = "",
         erSlettet: Boolean? = false,

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/AltinnTilgangerContainerHelper.kt
@@ -62,13 +62,8 @@ class AltinnTilgangerContainerHelper(
         overordnetEnhet: String = ALTINN_OVERORDNET_ENHET,
         underenhet: String,
         altinn3Rettighet: String = "",
-        erSlettet: Boolean? = false,
+        erSlettet: Boolean = false,
     ) {
-        val erSlettetJson = if (erSlettet != null) {
-            """ "erSlettet": $erSlettet, """
-        } else {
-            ""
-        }
         log.debug(
             "Oppretter MockServerClient med host '${container.host}' og port '${
                 container.getMappedPort(
@@ -103,12 +98,12 @@ class AltinnTilgangerContainerHelper(
                               "altinn2Tilganger": [],
                               "underenheter": [],
                               "navn": "NAVN TIL UNDERENHET",
-                              $erSlettetJson
+                              "erSlettet": $erSlettet,
                               "organisasjonsform": "BEDR"
                             }
                           ],
                           "navn": "NAVN TIL OVERORDNET ENHET",
-                          $erSlettetJson
+                          "erSlettet": $erSlettet,
                           "organisasjonsform": "ORGL"
                         }
                       ],

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/TestContainerHelper.kt
@@ -149,10 +149,10 @@ internal fun withTokenXToken(): HttpRequestBuilder.() -> Unit =
         header(HttpHeaders.Authorization, "Bearer ${TestContainerHelper.tokenXAccessToken().serialize()}")
     }
 
-val dummyJwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
+val ikkeGyldigJwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
 internal fun withoutGyldigTokenXToken(): HttpRequestBuilder.() -> Unit =
     {
-        header(HttpHeaders.Authorization, "Bearer $dummyJwtToken")
+        header(HttpHeaders.Authorization, "Bearer $ikkeGyldigJwtToken")
     }
 
 internal fun HttpRequestBuilder.medAzureToken(token: String = TestContainerHelper.azureAccessToken().serialize()) {

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/TestContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/TestContainerHelper.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -22,6 +23,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import no.nav.fia.arbeidsgiver.helper.AuthContainerHelper.Companion.SAKSBEHANDLER_GROUP_ID
 import no.nav.fia.arbeidsgiver.konfigurasjon.plugins.HEADER_SESJON_ID
+import no.nav.fia.arbeidsgiver.organisasjoner.api.ORGANISASJONER_PATH
 import no.nav.fia.arbeidsgiver.sporreundersokelse.api.BLI_MED_PATH
 import no.nav.fia.arbeidsgiver.sporreundersokelse.api.DELTAKER_BASEPATH
 import no.nav.fia.arbeidsgiver.sporreundersokelse.api.VERT_BASEPATH
@@ -80,7 +82,15 @@ class TestContainerHelper {
                         .plus(valkey.envVars())
                         .plus(altinnTilgangerContainerHelper.envVars()),
                 )
-                .apply { start() }
+                .apply {
+                    start()
+                }
+
+        suspend fun hentOrganisasjonerTilgangResponse(config: HttpRequestBuilder.() -> Unit = {}): HttpResponse =
+            applikasjon.performGet(
+                url = ORGANISASJONER_PATH,
+                config = config,
+            )
 
         internal fun tokenXAccessToken(
             subject: String = "123",
@@ -137,6 +147,12 @@ private suspend fun GenericContainer<*>.performRequest(
 internal fun withTokenXToken(): HttpRequestBuilder.() -> Unit =
     {
         header(HttpHeaders.Authorization, "Bearer ${TestContainerHelper.tokenXAccessToken().serialize()}")
+    }
+
+val dummyJwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
+internal fun withoutGyldigTokenXToken(): HttpRequestBuilder.() -> Unit =
+    {
+        header(HttpHeaders.Authorization, "Bearer $dummyJwtToken")
     }
 
 internal fun HttpRequestBuilder.medAzureToken(token: String = TestContainerHelper.azureAccessToken().serialize()) {

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerEndepunktTest.kt
@@ -68,11 +68,16 @@ class OrganisasjonerEndepunktTest {
             val altinnOrganisasjonForOverordnetEnhet: AltinnTilgang =
                 altinnOrganisasjoner.find { it.orgnr == ALTINN_OVERORDNET_ENHET }!!
             altinnOrganisasjonForOverordnetEnhet.navn shouldBe "NAVN TIL OVERORDNET ENHET"
+            altinnOrganisasjonForOverordnetEnhet.altinn3Tilganger.size shouldBe 0
+            altinnOrganisasjonForOverordnetEnhet.erSlettet shouldBe false
             altinnOrganisasjonForOverordnetEnhet.underenheter.size shouldBe 1
+
             val altinnOrganisasjonForUnderenhet: AltinnTilgang =
                 altinnOrganisasjonForOverordnetEnhet.underenheter.find { it.orgnr == ALTINN_ORGNR_1 }!!
             altinnOrganisasjonForUnderenhet.navn shouldBe "NAVN TIL UNDERENHET"
             altinnOrganisasjonForUnderenhet.altinn3Tilganger.size shouldBe 1
+            altinnOrganisasjonForOverordnetEnhet.erSlettet shouldBe false
+            altinnOrganisasjonForUnderenhet.underenheter.size shouldBe 0
         }
     }
 }

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/organisasjoner/api/OrganisasjonerEndepunktTest.kt
@@ -1,0 +1,78 @@
+package no.nav.fia.arbeidsgiver.organisasjoner.api
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import no.nav.fia.arbeidsgiver.helper.AltinnTilgangerContainerHelper.Companion.ALTINN_ORGNR_1
+import no.nav.fia.arbeidsgiver.helper.AltinnTilgangerContainerHelper.Companion.ALTINN_OVERORDNET_ENHET
+import no.nav.fia.arbeidsgiver.helper.TestContainerHelper
+import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
+import no.nav.fia.arbeidsgiver.helper.withTokenXToken
+import no.nav.fia.arbeidsgiver.helper.withoutGyldigTokenXToken
+import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.AltinnTilgang
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class OrganisasjonerEndepunktTest {
+    @BeforeTest
+    fun setup() {
+        runBlocking {
+            altinnTilgangerContainerHelper.slettAlleRettigheter()
+        }
+    }
+
+    @Test
+    fun `Uinnlogget bruker får en 401 - Not Authorized i response`() {
+        runBlocking {
+            val response = TestContainerHelper.hentOrganisasjonerTilgangResponse(
+                config = withoutGyldigTokenXToken(),
+            )
+
+            response.status.value shouldBe 401
+        }
+    }
+
+    @Test
+    fun `Innlogget bruker som ikke har noen rettigheter får en tom liste`() {
+        runBlocking {
+            val response = TestContainerHelper.hentOrganisasjonerTilgangResponse(
+                config = withTokenXToken(),
+            )
+
+            response.status.value shouldBe 200
+            val altinnOrganisasjoner = Json.decodeFromString<List<AltinnTilgang>>(response.bodyAsText())
+            altinnOrganisasjoner shouldNotBe null
+            altinnOrganisasjoner.size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `Innlogget bruker får hente organisasjoner hen har tilgang til`() {
+        altinnTilgangerContainerHelper.leggTilRettigheter(
+            overordnetEnhet = ALTINN_OVERORDNET_ENHET,
+            underenhet = ALTINN_ORGNR_1,
+            altinn3Rettighet = "En annen enkeltrettighet",
+        )
+
+        runBlocking {
+            val response = TestContainerHelper.hentOrganisasjonerTilgangResponse(
+                config = withTokenXToken(),
+            )
+
+            response.status.value shouldBe 200
+            val altinnOrganisasjoner = Json.decodeFromString<List<AltinnTilgang>>(response.bodyAsText())
+            altinnOrganisasjoner shouldNotBe null
+            altinnOrganisasjoner.size shouldBe 1
+            val altinnOrganisasjonForOverordnetEnhet: AltinnTilgang =
+                altinnOrganisasjoner.find { it.orgnr == ALTINN_OVERORDNET_ENHET }!!
+            altinnOrganisasjonForOverordnetEnhet.navn shouldBe "NAVN TIL OVERORDNET ENHET"
+            altinnOrganisasjonForOverordnetEnhet.underenheter.size shouldBe 1
+            val altinnOrganisasjonForUnderenhet: AltinnTilgang =
+                altinnOrganisasjonForOverordnetEnhet.underenheter.find { it.orgnr == ALTINN_ORGNR_1 }!!
+            altinnOrganisasjonForUnderenhet.navn shouldBe "NAVN TIL UNDERENHET"
+            altinnOrganisasjonForUnderenhet.altinn3Tilganger.size shouldBe 1
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
@@ -18,7 +18,7 @@ import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.kafka
 import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.shouldContainLog
 import no.nav.fia.arbeidsgiver.helper.performGet
 import no.nav.fia.arbeidsgiver.helper.withTokenXToken
-import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3
+import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.dto.SamarbeidsstatusDTO
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.dto.Samarbeidsstaus
 import org.junit.Before
@@ -85,7 +85,7 @@ class SamarbeidsstatusTest {
     fun `skal få 200 (OK) dersom man går mot status med gyldig token og underenhet er slettet`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
             erSlettet = true,
         )
         runBlocking {
@@ -100,7 +100,7 @@ class SamarbeidsstatusTest {
     fun `skal få 200 (OK) dersom man går mot status med gyldig token og altinn3 tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             applikasjon.performGet(
@@ -114,7 +114,7 @@ class SamarbeidsstatusTest {
     fun `skal få 200 (OK) dersom man går mot status med gyldig token, gammel acr og altinn tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             applikasjon.performGet("$SAMARBEIDSSTATUS_PATH/$ALTINN_ORGNR_1") {
@@ -137,7 +137,7 @@ class SamarbeidsstatusTest {
     fun `skal få 200 (OK) dersom man går mot status med gyldig token, ny acr og altinn tilgang`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             applikasjon.performGet("$SAMARBEIDSSTATUS_PATH/$ALTINN_ORGNR_1") {
@@ -189,7 +189,7 @@ class SamarbeidsstatusTest {
     fun `skal få ut samarbeidsstatus IKKE_I_SAMARBEID for virksomhet i status != VI_BISTÅR`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             kafka.sendStatusOppdateringForVirksomhet(ALTINN_ORGNR_1, "VURDERES")
@@ -208,7 +208,7 @@ class SamarbeidsstatusTest {
     fun `skal få ut samarbeidsstatus I_SAMARBEID for virksomhet i status VI_BISTÅR`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_1,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             kafka.sendStatusOppdateringForVirksomhet(ALTINN_ORGNR_1, "VI_BISTÅR")
@@ -227,7 +227,7 @@ class SamarbeidsstatusTest {
     fun `skal få samarbeidsstatus IKKE_I_SAMARBEID dersom vi ikke har noen data for virksomhet`() {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             underenhet = ALTINN_ORGNR_2,
-            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_ALTINN_3,
+            altinn3Rettighet = ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID,
         )
         runBlocking {
             val orgnr = ALTINN_ORGNR_2

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/samarbeidsstatus/api/SamarbeidsstatusTest.kt
@@ -181,7 +181,7 @@ class SamarbeidsstatusTest {
             )
 
             response.status shouldBe HttpStatusCode.Forbidden
-            response.bodyAsText() shouldContain "Ikke tilgang til orgnummer".toRegex()
+            response.bodyAsText() shouldContain "Har ikke tilgang til resurs for orgnummer".toRegex()
         }
     }
 


### PR DESCRIPTION
Nytt endepunkt `/organisasjoner` som returnerer en liste av alle organisasjoner en innlogget bruker har tilgang til.
Denne lista skal da kunne brukes som input til `virksomhetsvelger` i `min-ia`
