### PR TITLE
Offentlig id til samarbeid

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy branch to dev
     needs: build
-    if: github.ref == 'refs/heads/hent-samarbeid-i-lydia-api'
+    if: github.ref == 'refs/heads/offentlig-id-til-samarbeid'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ val opentelemetryLogbackMdcVersion = "2.16.0-alpha"
 val prometheusVersion = "1.15.2"
 val kotestVersion = "5.9.1"
 val testcontainersVersion = "1.21.3"
-val testMockServerVersion = "5.15.0"
+val mockServerVersion = "1.0.19"
 val valkeyVersion = "5.4.0"
 
 plugins {
@@ -70,8 +70,9 @@ dependencies {
 
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")
-    testImplementation("org.testcontainers:mockserver:$testcontainersVersion")
-    testImplementation("org.mock-server:mockserver-client-java:$testMockServerVersion")
+    // Mockserver neolight
+    testImplementation("software.xdev.mockserver:testcontainers:$mockServerVersion")
+    testImplementation("software.xdev.mockserver:client:$mockServerVersion")
 
     testImplementation("org.wiremock:wiremock-standalone:3.13.1")
     // Mock-oauth2-server

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,36 +86,6 @@ dependencies {
                 "ktor-client-apache:3.2.3 har en sårbar versjon av commons-codec",
             )
         }
-        testImplementation("com.google.guava:guava") {
-            version {
-                require("33.4.0-jre")
-            }
-            because("Mockserver har sårbar guava versjon")
-        }
-        testImplementation("commons-beanutils:commons-beanutils") {
-            version {
-                require("1.11.0")
-            }
-            because("mockserver-client-java imkluderer en sårbar versjon")
-        }
-        testImplementation("org.bouncycastle:bcprov-jdk18on") {
-            version {
-                require("1.81")
-            }
-            because("bcprov-jdk18on in Mockserver har sårbar versjon")
-        }
-        testImplementation("org.bouncycastle:bcpkix-jdk18on") {
-            version {
-                require("1.81")
-            }
-            because("bcpkix-jdk18on in Mockserver har sårbar versjon")
-        }
-        testImplementation("org.xmlunit:xmlunit-core") {
-            version {
-                require("2.10.3")
-            }
-            because("xmlunit-core in Mockserver har sårbar versjon")
-        }
         testImplementation("org.apache.commons:commons-compress") {
             version {
                 require("1.28.0")
@@ -127,17 +97,6 @@ dependencies {
                 require("2.20.0")
             }
             because("testcontainers har sårbar versjon")
-        }
-        testImplementation("com.jayway.jsonpath:json-path") {
-            version {
-                require("2.9.0")
-            }
-            because(
-                """
-                json-path v2.8.0 was discovered to contain a stack overflow via the Criteria.parse() method.
-                introdusert gjennom io.kotest:kotest-assertions-json:5.8.0 (Mockserver)
-                """.trimIndent(),
-            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidMedDokumenterDto.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidMedDokumenterDto.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SamarbeidMedDokumenterDto(
-    @Deprecated("Bruk offentligId istedenfor id")
-    val id: Int,
     val offentligId: String,
     val navn: String,
     val status: Status,

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidMedDokumenterDto.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidMedDokumenterDto.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SamarbeidMedDokumenterDto(
-    val id: Int, // TODO: uuid etc...
+    @Deprecated("Bruk offentligId istedenfor id")
+    val id: Int,
+    val offentligId: String,
     val navn: String,
     val status: Status,
     val sistEndret: LocalDateTime? = null,

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/DokumentPubliseringContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/DokumentPubliseringContainerHelper.kt
@@ -2,16 +2,20 @@ package no.nav.fia.arbeidsgiver.helper
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import no.nav.fia.arbeidsgiver.helper.HttpMockServerContainerUtils.Companion.createMockServerClient
+import no.nav.fia.arbeidsgiver.helper.HttpMockServerContainerUtils.Companion.resetAllExpectations
 import no.nav.fia.arbeidsgiver.proxy.dokument.DokumentService
-import org.mockserver.client.MockServerClient
-import org.mockserver.model.HttpRequest.request
-import org.mockserver.model.HttpResponse.response
 import org.slf4j.Logger
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.model.HttpRequest.request
+import software.xdev.mockserver.model.HttpResponse.response
+import software.xdev.testcontainers.mockserver.containers.MockServerContainer
+import software.xdev.testcontainers.mockserver.containers.MockServerContainer.PORT
 
 class DokumentPubliseringContainerHelper(
     network: Network = Network.newNetwork(),
@@ -21,11 +25,13 @@ class DokumentPubliseringContainerHelper(
         fun lagJsonForDokumentMock(dokument: DokumentService.DokumentDto): String = Json.encodeToString(dokument)
     }
 
-    private val networkAlias = "mockFiaDokumentPubliseringContainer"
-    private val port = 7171
+    private val networkAlias = "fia-dokument-publisering-container"
+    private val port =
+        PORT // mockserver default port er 1080 som MockServerContainer() eksponerer selv med "this.addExposedPort(1080);"
+    private var mockServerClient: MockServerClient? = null
 
-    private val dockerImageName = DockerImageName.parse("mockserver/mockserver")
-    val container: GenericContainer<*> = GenericContainer(dockerImageName)
+    private val dockerImageName = DockerImageName.parse("xdevsoftware/mockserver:1.0.19")
+    val container: GenericContainer<*> = MockServerContainer(dockerImageName)
         .withNetwork(network)
         .withNetworkAliases(networkAlias)
         .withExposedPorts(port)
@@ -41,6 +47,7 @@ class DokumentPubliseringContainerHelper(
         .apply {
             start()
         }.also {
+            mockServerClient = createMockServerClient(container = it, port = port)
             log.info("Startet (mock) fia-dokument-publisering container for network '$network' og port '$port'")
         }
 
@@ -49,26 +56,16 @@ class DokumentPubliseringContainerHelper(
             "FIA_DOKUMENT_PUBLISERING_URL" to "http://$networkAlias:$port",
         )
 
-    internal fun slettAlleDokumenter() {
-        val client = MockServerClient(
-            container.host,
-            container.getMappedPort(port),
-        )
-        client.reset()
-    }
+    internal fun slettAlleDokumenter() = resetAllExpectations(client = mockServerClient!!)
 
     internal fun leggTilDokument(
         orgnr: String,
         dokument: DokumentService.DokumentDto,
     ) {
         log.info("Legger til et dokument med dokumentId '${dokument.dokumentId}' for orgnr '$orgnr' i mockserver")
-        val client = MockServerClient(
-            container.host,
-            container.getMappedPort(port),
-        )
 
         runBlocking {
-            client.`when`(
+            mockServerClient!!.`when`(
                 request()
                     .withMethod("GET")
                     .withPath("/dokument/orgnr/$orgnr/dokumentId/${dokument.dokumentId}"),

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/HttpMockServerContainerUtils.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/HttpMockServerContainerUtils.kt
@@ -1,0 +1,61 @@
+package no.nav.fia.arbeidsgiver.helper
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.GenericContainer
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.model.Format
+import software.xdev.mockserver.model.RequestDefinition
+
+class HttpMockServerContainerUtils {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+        fun createMockServerClient(
+            container: GenericContainer<*>,
+            port: Int,
+        ): MockServerClient {
+            logger.info(
+                "Oppretter MockServerClient for container '${container.containerName}' med " +
+                    "host '${container.host}' og port '${
+                        container.getMappedPort(port)
+                    }'",
+            )
+            return MockServerClient(
+                container.host,
+                container.getMappedPort(port),
+            )
+        }
+
+        fun resetAllExpectations(client: MockServerClient) {
+            val allExpectations = hentAlleExpectationIds(client = client)
+
+            runBlocking {
+                allExpectations.forEach { expectation ->
+                    client.clear(expectation.id)
+                }
+                logger.info("Funnet og slettet '${allExpectations.size}' aktive expectations")
+            }
+            client.reset()
+        }
+
+        private fun hentAlleExpectationIds(client: MockServerClient): List<Expectation> =
+            runBlocking {
+                val alleAktiveRequestDefinition: RequestDefinition? = null
+                val activeExpectations = client.retrieveActiveExpectations(alleAktiveRequestDefinition, Format.JSON)
+                Json.decodeFromString<List<Expectation>>(activeExpectations)
+            }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Serializable
+    @JsonIgnoreUnknownKeys
+    internal data class Expectation(
+        val id: String,
+    )
+}

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/LydiaApiContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/LydiaApiContainerHelper.kt
@@ -57,7 +57,7 @@ class LydiaApiContainerHelper(
         orgnr: String,
         iaSamarbeidDto: SamarbeidMedDokumenterDto,
     ) {
-        log.info("Legger til et samarbeid med id '${iaSamarbeidDto.id}' for orgnr '$orgnr' i mockserver")
+        log.info("Legger til et samarbeid med offentligIg '${iaSamarbeidDto.offentligId}' for orgnr '$orgnr' i mockserver")
         val client = MockServerClient(
             container.host,
             container.getMappedPort(port),

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/LydiaApiContainerHelper.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/helper/LydiaApiContainerHelper.kt
@@ -1,10 +1,13 @@
 package no.nav.fia.arbeidsgiver.helper
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import no.nav.fia.arbeidsgiver.helper.HttpMockServerContainerUtils.Companion.createMockServerClient
 import no.nav.fia.arbeidsgiver.helper.HttpMockServerContainerUtils.Companion.resetAllExpectations
-import no.nav.fia.arbeidsgiver.proxy.samarbeid.SamarbeidMedDokumenterDto
+import no.nav.fia.arbeidsgiver.proxy.samarbeid.DokumentMetadata
+import no.nav.fia.arbeidsgiver.proxy.samarbeid.SamarbeidMedDokumenterDto.Companion.Status
 import org.slf4j.Logger
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
@@ -55,7 +58,7 @@ class LydiaApiContainerHelper(
 
     internal fun leggTilSamarbeid(
         orgnr: String,
-        iaSamarbeidDto: SamarbeidMedDokumenterDto,
+        iaSamarbeidDto: SamarbeidMedDokumenterV1Dto,
     ) {
         log.info("Legger til et samarbeid med offentligId '${iaSamarbeidDto.offentligId}' for orgnr '$orgnr' i mockserver")
 
@@ -71,4 +74,16 @@ class LydiaApiContainerHelper(
             )
         }
     }
+
+    @Serializable
+    data class SamarbeidMedDokumenterV1Dto(
+        // Ved å bruke denne versjonen av DTOen i testene sjekker vi at APIet ikke er avhengig av felter som ikke er i bruk
+        @Deprecated("Blir fjernet i en senere versjon. Bruk offentligId istedenfor id")
+        val id: Int,
+        val offentligId: String,
+        val navn: String,
+        val status: Status,
+        val sistEndret: LocalDateTime? = null,
+        val dokumenter: List<DokumentMetadata> = emptyList(),
+    )
 }

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidEndepunktTest.kt
@@ -7,6 +7,7 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import no.nav.fia.arbeidsgiver.helper.AltinnTilgangerContainerHelper.Companion.ALTINN_ORGNR_1
+import no.nav.fia.arbeidsgiver.helper.LydiaApiContainerHelper
 import no.nav.fia.arbeidsgiver.helper.TestContainerHelper
 import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
 import no.nav.fia.arbeidsgiver.helper.TestContainerHelper.Companion.lydiaApiContainerHelper
@@ -59,7 +60,7 @@ class SamarbeidEndepunktTest {
         )
         lydiaApiContainerHelper.leggTilSamarbeid(
             orgnr = "999888777",
-            iaSamarbeidDto = SamarbeidMedDokumenterDto(
+            iaSamarbeidDto = LydiaApiContainerHelper.SamarbeidMedDokumenterV1Dto(
                 id = 1234,
                 offentligId = UUID.randomUUID().toString(),
                 navn = "Avdeling Oslo",
@@ -93,7 +94,7 @@ class SamarbeidEndepunktTest {
         )
         lydiaApiContainerHelper.leggTilSamarbeid(
             orgnr = ALTINN_ORGNR_1,
-            iaSamarbeidDto = SamarbeidMedDokumenterDto(
+            iaSamarbeidDto = LydiaApiContainerHelper.SamarbeidMedDokumenterV1Dto(
                 id = 1234,
                 offentligId = UUID.randomUUID().toString(),
                 navn = "Avdeling Oslo",

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/samarbeid/SamarbeidEndepunktTest.kt
@@ -1,6 +1,8 @@
 package no.nav.fia.arbeidsgiver.proxy.samarbeid
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.UUIDVersion
+import io.kotest.matchers.string.shouldBeUUID
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -12,6 +14,7 @@ import no.nav.fia.arbeidsgiver.helper.withTokenXToken
 import no.nav.fia.arbeidsgiver.helper.withoutGyldigTokenXToken
 import no.nav.fia.arbeidsgiver.proxy.samarbeid.SamarbeidMedDokumenterDto.Companion.Status.AKTIV
 import no.nav.fia.arbeidsgiver.samarbeidsstatus.api.AltinnTilgangerService.Companion.ENKELRETTIGHET_FOREBYGGE_FRAVÆR_SAMARBEID
+import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -58,6 +61,7 @@ class SamarbeidEndepunktTest {
             orgnr = "999888777",
             iaSamarbeidDto = SamarbeidMedDokumenterDto(
                 id = 1234,
+                offentligId = UUID.randomUUID().toString(),
                 navn = "Avdeling Oslo",
                 status = AKTIV,
             ),
@@ -91,6 +95,7 @@ class SamarbeidEndepunktTest {
             orgnr = ALTINN_ORGNR_1,
             iaSamarbeidDto = SamarbeidMedDokumenterDto(
                 id = 1234,
+                offentligId = UUID.randomUUID().toString(),
                 navn = "Avdeling Oslo",
                 status = AKTIV,
             ),
@@ -111,6 +116,8 @@ class SamarbeidEndepunktTest {
             val result = Json.decodeFromString<List<SamarbeidMedDokumenterDto>>(response.bodyAsText())
             result.size shouldBe 1
             result.first().status shouldBe AKTIV
+            result.first().navn shouldBe "Avdeling Oslo"
+            result.first().offentligId.shouldBeUUID(version = UUIDVersion.ANY)
         }
     }
 }


### PR DESCRIPTION
Bruk av `offentligId` i stedet av `id` til et samarbeid 