### PR TITLE
Innhold i dokument som json

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     name: Deploy branch to dev
     needs: build
-    if: github.ref == 'refs/heads/offentlig-id-til-samarbeid'
+    if: github.ref == 'refs/heads/innhold-i-dokument-som-json'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentService.kt
@@ -13,6 +13,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import no.nav.fia.arbeidsgiver.http.HttpClient.client
 import no.nav.fia.arbeidsgiver.http.tokenx.TokenExchanger
 import no.nav.fia.arbeidsgiver.konfigurasjon.Miljø.cluster
@@ -73,6 +74,6 @@ class DokumentService {
         val dokumentId: String,
         val type: String,
         val samarbeidNavn: String,
-        val innhold: String,
+        val innhold: JsonObject,
     )
 }

--- a/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentService.kt
@@ -33,7 +33,7 @@ class DokumentService {
         token: String,
         orgnr: String,
         dokumentId: UUID,
-    ): DokumentDto? =
+    ): DokumentSvarTilFrontendDto? =
         try {
             val client = getHttpClient(token = token)
             val response: HttpResponse = client.get {
@@ -41,7 +41,7 @@ class DokumentService {
                 accept(ContentType.Application.Json)
             }
             if (response.status == HttpStatusCode.OK) {
-                json.decodeFromString<DokumentDto>(response.body())
+                json.decodeFromString<DokumentDto>(response.body()).tilDokumentFrontendDto()
             } else {
                 log.warn("Kunne ikke hente dokument fra Fia dokument publisering, ${response.status}")
                 null
@@ -76,4 +76,21 @@ class DokumentService {
         val samarbeidNavn: String,
         val innhold: JsonObject,
     )
+
+    @Serializable
+    data class DokumentSvarTilFrontendDto(
+        val dokumentId: String,
+        val type: String,
+        val samarbeidNavn: String,
+        val innhold: String,
+    )
+
+    @Deprecated("Få frontend til å håndtere innhold som JsonObject og bruk DokumentDto i stedet")
+    private fun DokumentDto.tilDokumentFrontendDto(): DokumentSvarTilFrontendDto =
+        DokumentSvarTilFrontendDto(
+            dokumentId = dokumentId,
+            type = type,
+            samarbeidNavn = samarbeidNavn,
+            innhold = innhold.toString(),
+        )
 }

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentEndepunktTest.kt
@@ -119,7 +119,7 @@ class DokumentEndepunktTest {
             )
 
             response.status.value shouldBe 200
-            val hentetDokument = Json.decodeFromString<DokumentService.DokumentDto>(response.bodyAsText())
+            val hentetDokument = Json.decodeFromString<DokumentService.DokumentSvarTilFrontendDto>(response.bodyAsText())
 
             hentetDokument shouldNotBe null
             hentetDokument.dokumentId shouldBe dokument.dokumentId

--- a/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/fia/arbeidsgiver/proxy/dokument/DokumentEndepunktTest.kt
@@ -56,7 +56,7 @@ class DokumentEndepunktTest {
             dokumentId = UUID.randomUUID().toString(),
             type = "BEHOVSVURDERING",
             samarbeidNavn = "Avdeling Oslo",
-            innhold = "{}",
+            innhold = Json.decodeFromString("{}"),
         )
         altinnTilgangerContainerHelper.leggTilRettighet(
             orgnrTilUnderenhet = ALTINN_ORGNR_1,
@@ -94,7 +94,7 @@ class DokumentEndepunktTest {
             dokumentId = UUID.randomUUID().toString(),
             type = "BEHOVSVURDERING",
             samarbeidNavn = "Avdeling Oslo",
-            innhold = "{}",
+            innhold = Json.decodeFromString("{}"),
         )
         altinnTilgangerContainerHelper.leggTilRettighet(
             orgnrTilUnderenhet = ALTINN_ORGNR_1,


### PR DESCRIPTION
Håndtere nytt format for innhold til et dokument, hentes som et JsonObject fra Fia-dokument-publisering og returneres som en String til front-end
OBS: krever at [følgende PR](https://github.com/navikt/fia-dokument-publisering/pull/7) blir merget først 